### PR TITLE
VIT-1191 add region api parameter

### DIFF
--- a/vital/api/link.py
+++ b/vital/api/link.py
@@ -32,7 +32,7 @@ class Link(API):
         )
 
     def email_provider(
-        self, link_token: str, provider: str, email: str
+        self, link_token: str, provider: str, email: str, region: Optional[str] = None
     ) -> Mapping[str, str]:
         """
         Connect a password auth provider.
@@ -43,7 +43,7 @@ class Link(API):
         """
         return self.client.post(
             f"/link/provider/email/{provider}",
-            {"email": email},
+            {"email": email, "region": region},
             headers={"LinkToken": link_token},
         )
 


### PR DESCRIPTION
CI is failing because our GitHub secrets are likely pointing to a user that doesn't exist anymore... That and the fact that we don't use client_id and client_secret anymore means that this relatively trivial change will require a lot more to get the tests passing. I vote for moving this to this ticket

[VIT-1214](https://linear.app/try-vital/issue/VIT-1214/fix-vital-python-and-vital-node-ci)