### PR TITLE
[VIT-1286] - Only append region if it's specified

### DIFF
--- a/vital/api/link.py
+++ b/vital/api/link.py
@@ -47,10 +47,13 @@ class Link(API):
         :param str username: username.
         :param str password: password.
         """
+        body = {"email": email}
+        if region:
+            body["region"] = region
         return self.client.post(
             f"/link/provider/email/{provider}",
-            {"email": email, "region": region},
-            headers={"LinkToken": link_token},
+            body,
+            headers={"x-vital-link-token": link_token},
         )
 
     def oauth_provider(


### PR DESCRIPTION
- This was causing a bug in our python client as the region was being included in the body as None. Despite it being Optional with defaults set, weird behaviour is being exhibited.