### PR TITLE
[VIT-2360] Rewrite the implementation of get_stream_for_date_range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vital"
-version = "1.3.6"
+version = "1.3.7"
 description = ""
 authors = ["maitham <maitham@tryvital.io>"]
 license = "GNU"

--- a/vital/api/sleep.py
+++ b/vital/api/sleep.py
@@ -45,7 +45,9 @@ class Sleep(API):
             end = arrow.get()
 
         if (end - arrow.get(start_date)).days > 7:
-            logger.warning("WARNING: calling get_stream_for_date_range for more than 7 days can significantly increase the latency of the request. Please consider reducing the number of days requested.")
+            logger.warning("WARNING: calling get_stream_for_date_range for "
+            "more than 7 days can significantly increase the latency of the request. "
+            "Please consider reducing the number of days requested.")
 
         summaries = self.get(user_id, start_date, end_date, provider)
         for sleep in summaries["sleep"]:

--- a/vital/api/sleep.py
+++ b/vital/api/sleep.py
@@ -1,6 +1,12 @@
+import logging
 from typing import List, Mapping, Optional
 
+import arrow
+
 from vital.api.api import API
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 
 class Sleep(API):
@@ -35,14 +41,17 @@ class Sleep(API):
         """
         GET Sleep stream data for a single sleep event's within date range.
         """
-        return self.client.get(
-            f"/summary/sleep/{user_id}/stream",
-            params={
-                "start_date": start_date,
-                "end_date": end_date,
-                "provider": provider,
-            },
-        )
+        if not end_date:
+            end = arrow.get()
+
+        if (end - arrow.get(start_date)).days > 7:
+            logger.warning("WARNING: calling get_stream_for_date_range for more than 7 days can significantly increase the latency of the request. Please consider reducing the number of days requested.")
+
+        summaries = self.get(user_id, start_date, end_date, provider)
+        for sleep in summaries["sleep"]:
+            sleep["sleep_stream"] = self.get_stream(sleep["id"])
+
+        return summaries
 
     def get_raw(
         self,

--- a/vital/api/sleep.py
+++ b/vital/api/sleep.py
@@ -1,12 +1,9 @@
-import logging
+import warnings
 from typing import List, Mapping, Optional
 
 import arrow
 
 from vital.api.api import API
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
 
 
 class Sleep(API):
@@ -45,7 +42,7 @@ class Sleep(API):
             end = arrow.get()
 
         if (end - arrow.get(start_date)).days > 7:
-            logger.warning("WARNING: calling get_stream_for_date_range for "
+            warnings.warn("WARNING: calling get_stream_for_date_range for "
             "more than 7 days can significantly increase the latency of the request. "
             "Please consider reducing the number of days requested.")
 

--- a/vital/api/sleep.py
+++ b/vital/api/sleep.py
@@ -42,9 +42,12 @@ class Sleep(API):
             end = arrow.get()
 
         if (end - arrow.get(start_date)).days > 7:
-            warnings.warn("WARNING: calling get_stream_for_date_range for "
-            "more than 7 days can significantly increase the latency of the request. "
-            "Please consider reducing the number of days requested.")
+            warnings.warn(
+                "WARNING: calling get_stream_for_date_range for "
+                "more than 7 days can significantly increase "
+                "the latency of the request. "
+                "Please consider reducing the number of days requested."
+            )
 
         summaries = self.get(user_id, start_date, end_date, provider)
         for sleep in summaries["sleep"]:


### PR DESCRIPTION
Do not use the `/summary/sleep/{user_id}/stream` endpoint anymore (soon to be deprecated), but instead fetch the sleep summaries first, and do a separate call to `/timeseries/sleep/{sleep_id}/stream` for each one of them.

Also, add a warning if the date range is >7 days.

I only changed the minor version because no method signature changed, just the implementation.