### PR TITLE
[CE-102] Remove beta note

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,6 @@ vital_client = Vital(
 )
 ```
 
-## Beta status
-
-This SDK is in beta, and there may be breaking changes between versions without a major version update. Therefore, we recommend pinning the package version to a specific version in your pyproject.toml file. This way, you can install the same version each time without breaking changes unless you are intentionally looking for the latest version.
 
 ## Contributing
 


### PR DESCRIPTION
The SDK is not in beta.

> In principle we do not do breaking changes to our Public API surface (expressed in terms of OpenAPI Schema). So the SDK generated from our OpenAPI Schema inherits that property

([reference](https://junctionapi.slack.com/archives/C0500Q1GFDZ/p1749822484982439))